### PR TITLE
part 2: analytical data model design (dv)

### DIFF
--- a/models/business_vault/hubs/hub_domains.sql
+++ b/models/business_vault/hubs/hub_domains.sql
@@ -1,0 +1,22 @@
+-- The hub_domains model is a hub that stores the natural key of the domain.
+with
+
+src as (
+    select
+        domain_urn as domain_nk  -- "natural key" for the domain
+    from {{ ref('rv_cleaned_domains') }}
+),
+
+hashes as (
+    select
+        domain_nk,
+        {{ dbt_utils.generate_surrogate_key(['domain_nk']) }} as domain_hk
+    from src
+)
+
+select
+    domain_hk,
+    domain_nk,
+    current_localtimestamp() as load_date,
+    'datahub_entities_raw' as record_source
+from hashes

--- a/models/business_vault/hubs/hub_entities.sql
+++ b/models/business_vault/hubs/hub_entities.sql
@@ -1,0 +1,22 @@
+-- The hub_entities model is a hub that stores the natural key of the entity.
+with
+
+src as (
+    select
+        entity_urn as entity_nk
+    from {{ ref('rv_cleaned_entities') }}
+),
+
+hashes as (
+    select
+        entity_nk,
+        {{ dbt_utils.generate_surrogate_key(['entity_nk']) }} as entity_hk
+    from src
+)
+
+select
+    entity_hk,
+    entity_nk,
+    current_localtimestamp() as load_date,
+    'datahub_entities_raw' as record_source
+from hashes

--- a/models/business_vault/links/lnk_domains_entities.sql
+++ b/models/business_vault/links/lnk_domains_entities.sql
@@ -1,0 +1,33 @@
+with
+
+raw as (
+    select
+        e.entity_urn,
+        -- if the domains JSON might include quoted strings, strip them
+        trim(both '"' from domain_flat.domain_urn) as domain_urn
+    from {{ ref('rv_cleaned_entities') }} e
+         -- use DuckDB's unnest approach here
+         , unnest(json_extract_string(e.domains, '$.domains')::string[]) as domain_flat(domain_urn)
+    where e.domains is not null
+      and e.entity_type in ('dataset','dashboard') 
+),
+
+join_hk as (
+    select
+        hent.entity_hk,
+        hdom.domain_hk
+    from raw r
+    -- join to the hub for entities
+    join {{ ref('hub_entities') }} hent
+      on hent.entity_nk = r.entity_urn
+    -- join to the hub for domains
+    join {{ ref('hub_domains') }} hdom
+      on hdom.domain_nk = r.domain_urn
+)
+
+select
+    domain_hk,
+    entity_hk,
+    current_localtimestamp() as load_date,
+    'datahub_entities_raw' as record_source
+from join_hk

--- a/models/business_vault/sats/sat_domains.sql
+++ b/models/business_vault/sats/sat_domains.sql
@@ -1,0 +1,36 @@
+-- Stores descriptive attributes for each domain (domain name, description, created by)
+with
+
+src as (
+    select
+        domain_urn,
+        domain_name,
+        domain_description,
+        domain_created_at,
+        domain_created_by
+    from {{ ref('rv_cleaned_domains') }}
+),
+
+join_hub as (
+    select
+        h.domain_hk,
+        s.domain_urn,
+        s.domain_name,
+        s.domain_description,
+        s.domain_created_at,
+        s.domain_created_by,
+        h.record_source
+    from src s
+    join {{ ref('hub_domains') }} h
+      on h.domain_nk = s.domain_urn
+)
+
+select
+    domain_hk,
+    domain_name,
+    domain_description,
+    domain_created_at,
+    domain_created_by,
+    current_localtimestamp() as load_date,
+    record_source
+from join_hub

--- a/models/business_vault/sats/sat_entities.sql
+++ b/models/business_vault/sats/sat_entities.sql
@@ -1,0 +1,42 @@
+-- Stores descriptive attributes for each entity (name, type, platform, creation info)
+with
+
+src as (
+    select
+        entity_urn,
+        entity_type,
+        entity_name,
+        platform,
+        origin,
+        entity_created_at,
+        entity_created_by
+    from {{ ref('rv_cleaned_entities') }}
+),
+
+join_hub as (
+    select
+        h.entity_hk,
+        s.entity_urn,
+        s.entity_type,
+        s.entity_name,
+        s.platform,
+        s.origin,
+        s.entity_created_at,
+        s.entity_created_by,
+        h.record_source
+    from src s
+    join {{ ref('hub_entities') }} h
+      on h.entity_nk = s.entity_urn
+)
+
+select
+    entity_hk,
+    entity_type,
+    entity_name,
+    platform,
+    origin,
+    entity_created_at,
+    entity_created_by,
+    current_localtimestamp() as load_date,
+    record_source
+from join_hub

--- a/models/mart/mrt_domain_analysis.sql
+++ b/models/mart/mrt_domain_analysis.sql
@@ -1,0 +1,32 @@
+-- Shows how many times each domain is applied to datasets/dashboards, along with domain descriptions
+with
+
+domain_entity_counts as (
+    select
+        d.domain_hk,
+        sd.domain_name,
+        sd.domain_description,
+        count(distinct e.entity_hk) as entity_count
+    from {{ ref('lnk_domains_entities') }} l
+    join {{ ref('hub_domains') }} d
+        on d.domain_hk = l.domain_hk
+    join {{ ref('sat_domains') }} sd
+        on sd.domain_hk = d.domain_hk
+    join {{ ref('hub_entities') }} e
+        on e.entity_hk = l.entity_hk
+    join {{ ref('sat_entities') }} se
+        on se.entity_hk = e.entity_hk
+    where se.entity_type in ('dataset','dashboard')
+    group by
+        d.domain_hk,
+        sd.domain_name,
+        sd.domain_description
+)
+
+select
+    domain_hk,
+    domain_name,
+    domain_description,
+    entity_count as total_entities,
+    rank() over (order by entity_count desc) as usage_rank
+from domain_entity_counts

--- a/models/raw_vault/rv_cleaned_domains.sql
+++ b/models/raw_vault/rv_cleaned_domains.sql
@@ -1,0 +1,21 @@
+-- Consolidates domain metadata from raw staging
+with
+
+domain_details as (
+    select
+        urn as domain_urn,
+        entity_details->>'name'        as domain_name,
+        entity_details->>'description' as domain_description,
+        entity_created_at              as domain_created_at,
+        entity_created_by              as domain_created_by
+    from {{ ref('stg_datahub_entities') }}
+    where entity_type = 'domain'
+)
+
+select distinct
+    domain_urn,
+    domain_name,
+    domain_description,
+    domain_created_at,
+    domain_created_by
+from domain_details

--- a/models/raw_vault/rv_cleaned_entities.sql
+++ b/models/raw_vault/rv_cleaned_entities.sql
@@ -1,0 +1,28 @@
+-- Consolidates dataset/dashboard metadata and retains JSON references to domains
+with
+
+entity_details as (
+    select
+        urn                             as entity_urn,
+        entity_type,
+        entity_details->>'name'         as entity_name,
+        entity_details->>'platform'     as platform,
+        entity_details->>'origin'       as origin,
+        domains,
+        entity_created_at,
+        entity_created_by
+    from {{ ref('stg_datahub_entities') }}
+    where entity_type IN ('dataset', 'dashboard') 
+    -- focus is on dataset/dashboard for the domain usage questions.
+)
+
+select distinct
+    entity_urn,
+    entity_type,
+    entity_name,
+    platform,
+    origin,
+    domains,
+    entity_created_at,
+    entity_created_by
+from entity_details

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -230,7 +230,7 @@ models:
   # ---------------------------------------------------------------------------
   #  DATA VAULT: LINK
   # ---------------------------------------------------------------------------
-  - name: lnk_domain_entities
+  - name: lnk_domains_entities
     description: >
       Data Vault Link capturing many-to-many relationships between domains and 
       entities. Each row represents a single (domain_hk, entity_hk) pair derived 
@@ -256,7 +256,7 @@ models:
   # ---------------------------------------------------------------------------
   #  MART
   # ---------------------------------------------------------------------------
-  - name: mrt_domain_usage
+  - name: mrt_domain_analysis
     description: >
       Final reporting (mart) model showing domain usage across datasets/dashboards. 
       Provides counts of how many entities belong to each domain, along with the 

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -3,9 +3,11 @@ version: 2
 seeds:
   - name: datahub_entities_raw
     description: >
-      Seed table with raw data from a fictional DataHub implementation. Each row represents a relationship 
-      between a DataHub Entity and an Aspect. A single Entity can have multiple records.
-      This should only be used for reference for those who are intersted in understanding the raw data used to create `stg_datahub_entities`.
+      Seed table with raw data from a fictional DataHub implementation. Each row 
+      represents a relationship between a DataHub Entity and an Aspect. A single Entity 
+      can have multiple records.
+      This should only be used for reference for those who are intersted in understanding 
+      the raw data used to create `stg_datahub_entities`.
       Assume this dataset is updated daily.
     columns:
       - name: urn
@@ -20,9 +22,14 @@ seeds:
         description: "Identifier of the User or process that created the record."
 
 models:
+  # ---------------------------------------------------------------------------
+  #  STAGING
+  # ---------------------------------------------------------------------------
   - name: stg_datahub_entities
     description: >
-      Staging table built on top of `datahub_entities_raw`, raw data from a fictional DataHub implementation. Each record represents an Entity and its relationships to Domains, Glossary Terms, and Owners where relevant.
+      Staging table built on top of `datahub_entities_raw`, raw data from a fictional 
+      DataHub implementation. Each record represents an Entity and its relationships 
+      to Domains, Glossary Terms, and Owners where relevant.
     columns:
       - name: urn
         description: "Unique identifier for the DataHub Entity."
@@ -30,7 +37,11 @@ models:
           - unique
           - not_null
       - name: entity_type
-        description: "Type of DataHub Entity. Datasets and Dashboards represent external Data Entities that have been ingested into DataHub. Domains and Glossary Terms are created and maintained in DataHub, used to organize and govern Data Entities. Users in DataHub can be assigned as Owners of Data Entities."
+        description: >
+          Type of DataHub Entity. Datasets and Dashboards represent external Data 
+          Entities that have been ingested into DataHub. Domains and Glossary Terms 
+          are created and maintained in DataHub, used to organize and govern Data Entities. 
+          Users in DataHub can be assigned as Owners of Data Entities.
         tests:
           - accepted_values:
               values: ['dataset', 'dashboard', 'domain', 'glossary_term', 'user']
@@ -41,20 +52,223 @@ models:
       - name: entity_created_by
         description: "Identifier of the User or process that created the Entity."
       - name: domains
-        description: "Domain assigned to the Dataset/Dashboard, used to represent organizational ownership of data assets, i.e. Finance, Marketing, Sales. Only one Domain can be assigned at any given time, but assignment can change over time. Domains cannot be assigned to Gossary Terms or Users."
+        description: >
+          Domain assigned to the Dataset/Dashboard, used to represent organizational 
+          ownership of data assets, i.e. Finance, Marketing, Sales. Only one Domain 
+          can be assigned at any given time, but assignment can change over time. 
+          Domains cannot be assigned to Gossary Terms or Users.
       - name: domains_added_at
         description: "Timestamp when the Domain was associated with the Entity."
       - name: domains_added_by
         description: "Identifier of the User or process that added the Domain."
       - name: glossary_terms
-        description: "List of Glossary Terms associated with the Dataset/Dashboard. Glossary Terms represent agreed-upon definitions of key business terms, helping with consistency in how metrics and dimensions are defined across data assets. There is no limit to the number of Terms that can be assigned to an Entity; Terms can be added and removed over time. Terms cannot be assigned to Domains or Users"
+        description: >
+          List of Glossary Terms associated with the Dataset/Dashboard. Glossary Terms 
+          represent agreed-upon definitions of key business terms, helping with 
+          consistency in how metrics and dimensions are defined across data assets. 
+          There is no limit to the number of Terms that can be assigned to an Entity; 
+          Terms can be added and removed over time. Terms cannot be assigned to Domains or Users.
       - name: glossary_terms_added_at
         description: "Timestamp when Glossary Terms were associated with the Entity."
       - name: glossary_terms_added_by
         description: "Identifier of the User or process that added Glossary Terms."
       - name: owners
-        description: "List of Users and their Ownership Type associated with the Dataset/Dashboard. There is no limit to the number of Owners that can be assigned; a single User can be assigned to multiple Ownership Types. Owners can be added or removed over time. Owners cannot be assigned to Domains or Glossary Terms."
+        description: >
+          List of Users and their Ownership Type associated with the Dataset/Dashboard. 
+          There is no limit to the number of Owners that can be assigned; a single User can 
+          be assigned to multiple Ownership Types. Owners can be added or removed over time. 
+          Owners cannot be assigned to Domains or Glossary Terms.
       - name: owners_added_at
         description: "Timestamp when Owners were associated with the Entity."
       - name: owners_added_by
         description: "Identifier of the User or process that added Owners."
+
+  # ---------------------------------------------------------------------------
+  #  RAW VAULT (INT) LAYER
+  # ---------------------------------------------------------------------------
+  - name: rv_cleaned_domains
+    description: >
+      Intermediate model extracting only Entities where entity_type = 'domain'. 
+      Pulls the domain's name, description, and creation metadata from JSON fields.
+    columns:
+      - name: domain_urn
+        description: "Unique domain identifier (natural key)."
+        tests:
+          - not_null
+      - name: domain_name
+        description: "Human-readable domain name parsed from the JSON metadata."
+      - name: domain_description
+        description: "Short description of the domain's purpose or scope."
+      - name: domain_created_at
+        description: "Timestamp when the domain was created in DataHub."
+      - name: domain_created_by
+        description: "Identifier of the User/process that created the domain."
+
+  - name: rv_cleaned_entities
+    description: >
+      Intermediate model focusing on 'dataset' and 'dashboard' Entities. 
+      Extracts key fields (e.g. entity_name, platform) from JSON metadata and 
+      retains JSON references to domains.
+    columns:
+      - name: entity_urn
+        description: "Unique entity identifier (natural key)."
+        tests:
+          - not_null
+      - name: entity_type
+        description: "Either 'dataset' or 'dashboard' for this model."
+      - name: entity_name
+        description: "Human-readable name, extracted from JSON metadata."
+      - name: platform
+        description: "Origin or platform reference (e.g. 'bigquery', 'looker')."
+      - name: origin
+        description: "Specifies environment or data region info if available."
+      - name: domains
+        description: "JSON array listing domain URNs assigned to this Entity."
+      - name: entity_created_at
+        description: "Timestamp when the entity was created."
+      - name: entity_created_by
+        description: "Identifier of the User/process that created the entity."
+
+  # ---------------------------------------------------------------------------
+  #  DATA VAULT: HUBS
+  # ---------------------------------------------------------------------------
+  - name: hub_domains
+    description: >
+      Data Vault Hub for domain entities. Each record represents a unique domain 
+      identified by domain_nk (the domain_urn).
+    columns:
+      - name: domain_hk
+        description: >
+          Surrogate key for the domain (hash of domain_nk). 
+          This is the primary key for this hub.
+        tests:
+          - unique
+          - not_null
+      - name: domain_nk
+        description: "Natural key (domain_urn) for the domain."
+        tests:
+          - not_null
+      - name: load_date
+        description: "Timestamp when the row was loaded into the Hub."
+      - name: record_source
+        description: "Identifier of the data source or pipeline stage."
+
+  - name: hub_entities
+    description: >
+      Data Vault Hub for dataset or dashboard entities. Each record has a unique 
+      entity_hk (hash of entity_nk), referencing the entity URN as the natural key.
+    columns:
+      - name: entity_hk
+        description: "Surrogate key for the entity (hash of entity_urn)."
+        tests:
+          - unique
+          - not_null
+      - name: entity_nk
+        description: "Natural key for the entity (the entity_urn)."
+        tests:
+          - not_null
+      - name: load_date
+        description: "Timestamp when the row was loaded into the Hub."
+      - name: record_source
+        description: "Identifier of the data source or pipeline stage."
+
+  # ---------------------------------------------------------------------------
+  #  DATA VAULT: SATELLITES
+  # ---------------------------------------------------------------------------
+  - name: sat_domains
+    description: >
+      Satellite table holding descriptive attributes of each domain. 
+      Linked to hub_domains by domain_hk.
+    columns:
+      - name: domain_hk
+        description: "FK referencing hub_domains.domain_hk."
+        tests:
+          - relationships:
+              to: 'hub_domains'
+              field: domain_hk
+      - name: domain_name
+        description: "Name of the domain (parsed from JSON)."
+      - name: domain_description
+        description: "Description of the domain (parsed from JSON)."
+      - name: domain_created_at
+        description: "Timestamp when the domain was created in DataHub."
+      - name: domain_created_by
+        description: "Identifier of the User/process that created the domain."
+      - name: load_date
+        description: "Timestamp when the row was loaded into the Satellite."
+      - name: record_source
+        description: "Identifier of the data source or pipeline stage."
+
+  - name: sat_entities
+    description: >
+      Satellite table for dataset/dashboard descriptive attributes. 
+      Linked to h_entities by entity_hk.
+    columns:
+      - name: entity_hk
+        description: "FK referencing hub_entities.entity_hk."
+        tests:
+          - relationships:
+              to: 'hub_entities'
+              field: entity_hk
+      - name: entity_type
+        description: "Indicates if this record is a dataset or a dashboard."
+      - name: entity_name
+        description: "Human-readable name for the dataset/dashboard."
+      - name: platform
+        description: "Platform or system in which the dataset/dashboard resides."
+      - name: origin
+        description: "Environment or location reference for the entity."
+      - name: entity_created_at
+        description: "Timestamp when the entity was created."
+      - name: entity_created_by
+        description: "Identifier of the User/process that created the entity."
+      - name: load_date
+        description: "Timestamp when the row was loaded into the Satellite."
+      - name: record_source
+        description: "Identifier of the data source or pipeline stage."
+
+  # ---------------------------------------------------------------------------
+  #  DATA VAULT: LINK
+  # ---------------------------------------------------------------------------
+  - name: lnk_domain_entities
+    description: >
+      Data Vault Link capturing many-to-many relationships between domains and 
+      entities. Each row represents a single (domain_hk, entity_hk) pair derived 
+      from flattening JSON references in int_clean_entities.domains.
+    columns:
+      - name: domain_hk
+        description: "FK referencing h_domains.domain_hk."
+        tests:
+          - relationships:
+              to: 'hub_domains'
+              field: domain_hk
+      - name: entity_hk
+        description: "FK referencing h_entities.entity_hk."
+        tests:
+          - relationships:
+              to: 'hub_entities'
+              field: entity_hk
+      - name: load_date
+        description: "Timestamp when the row was loaded into the Link."
+      - name: record_source
+        description: "Identifier of the data source or pipeline stage."
+
+  # ---------------------------------------------------------------------------
+  #  MART
+  # ---------------------------------------------------------------------------
+  - name: mrt_domain_usage
+    description: >
+      Final reporting (mart) model showing domain usage across datasets/dashboards. 
+      Provides counts of how many entities belong to each domain, along with the 
+      domain name/description.
+    columns:
+      - name: domain_hk
+        description: "FK referencing h_domains.domain_hk."
+      - name: domain_name
+        description: "Domain name, from s_domains."
+      - name: domain_description
+        description: "Domain description, from s_domains."
+      - name: total_entities
+        description: "Number of distinct datasets/dashboards associated with this domain."
+      - name: usage_rank
+        description: "Rank (descending) of domains by total_entities (1 = most used)."

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/dbt_utils
+    version: 1.3.0


### PR DESCRIPTION
The solution follows a Data Vault 2.0 approach:

1. Hubs

- hub_entities: Identifies unique entities using their URNs as natural keys.

- hub_domains: Identifies unique domains using domain URNs.

2. Satellites

- sat_entities: Stores descriptive attributes for each entity (name, type, platform, creation info).

- sat_domains: Stores descriptive attributes for each domain (domain name, description, created by).

3. Link

- lnk_domains_entities: Defines the many-to-many relationship between domains and entities. JSON arrays are flattened to allow each domain reference to join an entity.

4. Raw Vault Int Layer

- rv_cleaned_domains: Consolidates domain metadata from raw staging.

- rv_cleaned_entities: Consolidates dataset/dashboard metadata and retains JSON references to domains.

5. Mart

- mrt_domain_analysis: Provides a “star-schema-like” aggregation for easy reporting on domain usage.



Assumptions:

- Domain URNs Are Unique

- Each dataset, dashboard, or user has a unique URN that can join to the hub.

- Some domains may appear both as “domain” entity types in stg_datahub_entities and as references in the JSON domains field. The Data Vault unifies both if they share the same URN.

- We assume that the JSON array domains in rv_cleaned_entities is an accurate reflection of all domains linked to that entity. 

- We are not capturing SCD's


Future Improvements:

- Incremental models for more advanced change data capture. We can add valid to / valid from datetimes to track attribute changes over time.

- Right now, we lump “datasets” and “dashboards” into a single entity model. If we needed to treat these differently, consider separate Satellite structures or additional columns in sat_entities to handle sub-type attributes.

- The same pattern can be extended to “glossary_terms” or “owners” references if you want a many-to-many relationship with Entities. You’d just build additional Hubs, Satellites, and Links for those.


mrt_domain_analysis: output

![domain_analysis_usage](https://github.com/user-attachments/assets/a610032f-d6c3-4157-827a-0a5a90a584c6)

